### PR TITLE
Correct minor typos

### DIFF
--- a/scripts/grade-utils.sh
+++ b/scripts/grade-utils.sh
@@ -71,7 +71,7 @@ _run_tests_with() {
 # example: run_tests
 # Uses global variable RUNNER and TESTS
 run_tests() {
-    # "cargo --relase" should be split into "cargo" and "--release"
+    # "cargo --release" should be split into "cargo" and "--release"
     local IFS=' '
     echo $(_run_tests_with $RUNNER)
 }

--- a/src/assignments/assignment02.rs
+++ b/src/assignments/assignment02.rs
@@ -21,7 +21,7 @@ pub(crate) fn capitalize(input: String) -> String {
     todo!()
 }
 
-/// Returns the sume of the given array. (We assume the absence of integer overflow.)
+/// Returns the sum of the given array. (We assume the absence of integer overflow.)
 pub(crate) fn sum_array(input: &[u64]) -> u64 {
     todo!()
 }

--- a/src/assignments/assignment02.rs
+++ b/src/assignments/assignment02.rs
@@ -8,11 +8,11 @@
 
 use std::ops::Mul;
 
-const FARHENHEIT_OFFSET: f64 = 32.0;
-const FARHENHEIT_SCALE: f64 = 5.0 / 9.0;
+const FAHRENHEIT_OFFSET: f64 = 32.0;
+const FAHRENHEIT_SCALE: f64 = 5.0 / 9.0;
 
-/// Converts Farenheit to Celcius temperature degree.
-pub(crate) fn farhenheit_to_celcius(degree: f64) -> f64 {
+/// Converts Fahrenheit to Celsius temperature degree.
+pub(crate) fn fahrenheit_to_celsius(degree: f64) -> f64 {
     todo!()
 }
 

--- a/src/assignments/assignment02_grade.rs
+++ b/src/assignments/assignment02_grade.rs
@@ -3,9 +3,9 @@ mod test {
     use super::super::assignment02::*;
 
     #[test]
-    fn test_farenheit() {
-        assert_eq!(farhenheit_to_celcius(32.0), 0.0);
-        assert_eq!(farhenheit_to_celcius(212.0), 100.0);
+    fn test_fahrenheit() {
+        assert_eq!(fahrenheit_to_celsius(32.0), 0.0);
+        assert_eq!(fahrenheit_to_celsius(212.0), 100.0);
     }
 
     #[test]


### PR DESCRIPTION
This revision includes:
- Correct minor typos
  - relase -> release
  - farenheit, farhenheit -> fahrenheit
  - celcius -> celsius
  - sume -> sum