### PR TITLE
fix typo in derive of multiplication test

### DIFF
--- a/src/assignments/assignment06/symbolic_differentiation_grade.rs
+++ b/src/assignments/assignment06/symbolic_differentiation_grade.rs
@@ -172,7 +172,7 @@ mod test {
         // Mult
         //
         // d/dx (2x^4 * cos(x) * exp(x)) =
-        // 8x^2 * cos(x) * exp(x) - 2x^4 * sin(x) * exp(x) + 2x^4 * cos(x) * exp(x)
+        // 8x^3 * cos(x) * exp(x) - 2x^4 * sin(x) * exp(x) + 2x^4 * cos(x) * exp(x)
         let f1 = SingletonPolynomial::new_poly(TWO, FOUR);
         let f2 = Trignometric::new_cosine(ONE);
         let f3 = Exp::new();


### PR DESCRIPTION
the derivation of 2x^4 should be 8x^3