### PR TITLE
[Assignment09] `matmul` should be graded

### DIFF
--- a/scripts/grade.sh
+++ b/scripts/grade.sh
@@ -72,6 +72,7 @@ case $TEST_NAME in
     TEST09)
         TESTS=(
             "assignments::assignment09::bigint_grade::test"
+	    "assignments::assignment09::matmul_grade::test"
             "assignments::assignment09::small_exercises_grade::test"
         )
         ;;


### PR DESCRIPTION
`matmul_grade` was excluded in the grading script. I thought it was not intended, so added it.