### PR TITLE
Improve test code for pythagorean (assignment10)

### DIFF
--- a/src/assignments/assignment10/small_exercises_grade.rs
+++ b/src/assignments/assignment10/small_exercises_grade.rs
@@ -340,12 +340,17 @@ mod test {
             (68, 285, 293),
         ];
 
-        for (i, t) in pythagorean().enumerate().take(1000) {
-            if i < pythagoreans.len() {
-                assert_eq!(pythagoreans[i], t)
-            }
-            let (a, b, c) = t;
+        let mut pythagorean_iter = pythagorean();
+        for i in 0..1000 {
+            let t = pythagorean_iter.next();
+            assert!(t.is_some());
+
+            let (a, b, c) = t.unwrap();
             assert_eq!(a * a + b * b, c * c);
+
+            if i < pythagoreans.len() {
+                assert_eq!(pythagoreans[i], (a, b, c))
+            }
         }
     }
 }


### PR DESCRIPTION
Hi. I found out that current test code for pythagorean has some loophole,
so I'd like to suggest simple improvement for this.

According to Rust docs (https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.take),
```
take(n) yields elements until n elements are yielded or the end of the iterator is reached (whichever happens first). 
```

The original test code will be succeed if pythagorean() behaves just like std::iter::empty().
```rs
for (i, t) in pythagorean().enumerate().take(1000) {
    // never reached if pythagorean() is an empty iterator
    if i < pythagoreans.len() {
        assert_eq!(pythagoreans[i], t)
    }
    let (a, b, c) = t;
    assert_eq!(a * a + b * b, c * c);
}
```

Simplified sample code for explanation:
```rs
use core::panic;

fn main() {
    let it = std::iter::empty::<usize>();

    for (_i, _e) in it.enumerate().take(1000) {
        panic!("reached inside for-loop")
    }
}
```
Result:
```
$ cargo run    
   Compiling playground v0.1.0 (/root/cs220/playground)
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/playground`

/* dosen't panic */
```

So, I'd like to suggest improved test code as follows:
```rs
#[test]
fn test_pythagorean() {
    let pythagoreans = [ ... ]

    let mut pythagorean_iter = pythagorean();
    for i in 0..1000 {
        let t = pythagorean_iter.next();
        assert!(t.is_some());

        let (a, b, c) = t.unwrap();
        assert_eq!(a * a + b * b, c * c);

        if i < pythagoreans.len() {
            assert_eq!(pythagoreans[i], (a, b, c))
        }
    }
}
```

This code checks whether yielded value is not `None` at `assert!(t.is_some())`, preventing the unintended behavior above.

